### PR TITLE
Enable call recordings endpoint

### DIFF
--- a/lib/ex_twilio/api.ex
+++ b/lib/ex_twilio/api.ex
@@ -89,7 +89,7 @@ defmodule ExTwilio.Api do
   @spec update(atom, String.t(), data, list, list) :: Parser.success() | Parser.error()
   def update(module, sid, data, options \\ [], request_opts \\ [])
 
-  def update(module, sid, data, options, request_opts) when is_binary(sid),
+  def update(module, sid, data, options, request_opts) when is_nil(sid) or is_binary(sid),
     do: do_update(module, sid, data, options, request_opts)
 
   def update(module, %{sid: sid}, data, options, request_opts),

--- a/lib/ex_twilio/resources/recording.ex
+++ b/lib/ex_twilio/resources/recording.ex
@@ -14,7 +14,7 @@ defmodule ExTwilio.Recording do
             api_version: nil,
             uri: nil
 
-  use ExTwilio.Resource, import: [:stream, :all, :find, :destroy]
+  use ExTwilio.Resource, import: [:stream, :all, :find, :destroy, :update]
 
-  def parents, do: [:account]
+  def parents, do: [:account, :call]
 end


### PR DESCRIPTION
Enables the endpoint
`POST https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/Calls/{CallsSid}/Recordings.json`

https://www.twilio.com/docs/voice/api/recording#create-a-recording-resource